### PR TITLE
Fixes some errors resulting in exceptions

### DIFF
--- a/src/mqttsn/lib/message_headers.py
+++ b/src/mqttsn/lib/message_headers.py
@@ -53,8 +53,14 @@ class MessageHeaders:
             return chr_(length + 1)
         elif self._is_long_buffer(length + 3):
             return chr_(1) + write_int_16(length + 3)
+        elif length == 1:
+            """
+                control message: header only, no payload: 1 octet plus
+                length field: 1 octet
+            """
+            return chr_(length + 1)
         else:
-            raise "Invalid buffer size"
+            raise Exception(str("Invalid buffer size "+str(length)))
 
     def unpack(self, buffer):
         """

--- a/src/mqttsn/lib/publishes.py
+++ b/src/mqttsn/lib/publishes.py
@@ -59,11 +59,11 @@ class Publishes(Packets):
         pos += self.flags.unpack(buffer[pos:])
 
         self.topic_id = 0
-        self.topic_name = ""
+        self.topic_name = str("").encode()
         if self.flags.topic_id_type in [TOPIC_NORMAL, TOPIC_PREDEFINED]:
             self.topic_id = read_int_16(buffer[pos:])
         elif self.flags.topic_id_type == TOPIC_SHORTNAME:
-            self.topic_name = buffer[pos:pos + 2]
+            self.topic_name = str(buffer[pos:pos + 2]).encode()
 
         pos += 2
         self.msg_id = read_int_16(buffer[pos:])


### PR DESCRIPTION
Hi,
This PR fixes two problems I've run into when running the example script:
- "str has no decode property" when processing topic_name in _process_publish
- encode_length failing to compute length of DISCONNECT message.
I hope you'll find these fixes useful enough to merge them back.

Cheers,
Maciej